### PR TITLE
Fix code scanning alert no. 8: Incomplete URL substring sanitization

### DIFF
--- a/erpnext/setup/doctype/currency_exchange/test_currency_exchange.py
+++ b/erpnext/setup/doctype/currency_exchange/test_currency_exchange.py
@@ -3,7 +3,7 @@
 
 import unittest
 from unittest import mock
-
+from urllib.parse import urlparse
 import frappe
 from frappe.utils import cint, flt
 
@@ -68,9 +68,9 @@ def patched_requests_get(*args, **kwargs):
 		if kwargs["params"].get("date") and kwargs["params"].get("from") and kwargs["params"].get("to"):
 			if test_exchange_values.get(kwargs["params"]["date"]):
 				return PatchResponse({"result": test_exchange_values[kwargs["params"]["date"]]}, 200)
-	elif args[0].startswith("https://frankfurter.app") and kwargs.get("params"):
+	elif urlparse(args[0]).hostname == "frankfurter.app" and kwargs.get("params"):
 		if kwargs["params"].get("base") and kwargs["params"].get("symbols"):
-			date = args[0].replace("https://frankfurter.app/", "")
+			date = urlparse(args[0]).path.lstrip("/")
 			if test_exchange_values.get(date):
 				return PatchResponse(
 					{"rates": {kwargs["params"].get("symbols"): test_exchange_values.get(date)}}, 200


### PR DESCRIPTION
Fixes [https://github.com/offsoc/erpnext/security/code-scanning/8](https://github.com/offsoc/erpnext/security/code-scanning/8)

To fix the problem, we need to parse the URL and check the hostname instead of using the `startswith` method. This ensures that the URL is correctly validated and not susceptible to manipulation. We will use the `urlparse` function from the `urllib.parse` module to achieve this.

1. Import the `urlparse` function from the `urllib.parse` module.
2. Parse the URL using `urlparse`.
3. Check if the hostname of the parsed URL matches "frankfurter.app".


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
